### PR TITLE
Fix missing Trivy config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,30 @@ jobs:
       run: |
         safety check
 
+  security:
+    runs-on: ubuntu-latest
+    if: github.event_name != 'workflow_call'
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Run Trivy vulnerability scanner
+      uses: aquasecurity/trivy-action@master
+      with:
+        scan-type: 'fs'
+        scan-ref: '.'
+        format: 'sarif'
+        output: 'trivy-results.sarif'
+        severity: 'CRITICAL,HIGH'
+
+    - name: Upload Trivy scan results to GitHub Security tab
+      uses: github/codeql-action/upload-sarif@v3
+      if: always()
+      with:
+        sarif_file: 'trivy-results.sarif'
+
   build:
     runs-on: ubuntu-latest
     needs: [test]


### PR DESCRIPTION
## Summary
- restore the `security` job in CI for Trivy scanning

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e5f3914848333809f8293e0f33ecb