### PR TITLE
Fix example README Python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ A clean, intuitive Python client for The Graph Token API with elegant EVM/SVM se
 
 ## Quick Start
 
+### Requirements
+
+- Python 3.13+
+
 ### Installation
 
 ```bash

--- a/examples/endpoints/evm/README.md
+++ b/examples/endpoints/evm/README.md
@@ -37,7 +37,7 @@ python3 examples/endpoints/evm/swaps.py
 ## Requirements
 
 1. **API Key**: Set `THEGRAPH_API_KEY` in your `.env` file
-2. **Python 3.8+** with `anyio` and other dependencies
+2. **Python 3.13+** with `anyio` and other dependencies
 
 ## Usage Pattern
 

--- a/examples/endpoints/svm/README.md
+++ b/examples/endpoints/svm/README.md
@@ -29,7 +29,7 @@ python3 examples/endpoints/svm/swaps.py
 ## Requirements
 
 1. **API Key**: Set `THEGRAPH_API_KEY` in your `.env` file
-2. **Python 3.8+** with `anyio` and other dependencies
+2. **Python 3.13+** with `anyio` and other dependencies
 
 ## Usage Pattern
 


### PR DESCRIPTION
## Summary
- fix the Python version in the example READMEs to match the project requirement
- add a Requirements section with Python 3.13+ to the main README

## Testing
- `ruff check .`
- `ruff format --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e5dd078dc83339d84dd4f8f9c7ebc