### PR TITLE
Fix PyPI workflow permissions

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -10,7 +10,10 @@ jobs:
   # Run CI tests first to ensure quality
   test:
     uses: ./.github/workflows/ci.yml
-    secrets: inherit
+    secrets: inherit  # pragma: allowlist secret
+    permissions:
+      contents: read
+      security-events: write
 
   build:
     name: Build distribution


### PR DESCRIPTION
## Summary
- set permissions for nested CI workflow in `pypi-publish.yml`

## Testing
- `pre-commit run --files .github/workflows/pypi-publish.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e78d27c248333aab198b20c9174d3